### PR TITLE
build: Update version string in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@serialport/bindings",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -74,6 +74,7 @@
     },
     "nan": {
       "version": "git+ssh://git@github.com/brightsign/nan.git#6170c3b6a908ca3a56c4eeb1fd4d5eff37771d88",
+      "integrity": "sha512-dY4hDZspr17rTwRSEpcewhTZweXZrBh8HK9L4QeN+xQBRWLvdgLpQB/243uS0JlavWPmUKcWZLLVJab9Dxq0bw==",
       "from": "nan@github:brightsign/nan#6170c3b"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serialport/bindings",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha.1",
   "main": "lib",
   "keywords": [
     "serialport-binding"


### PR DESCRIPTION
NPM tries to use a cached version if version number matches one in the cache. Our version is not same as 9.0.0